### PR TITLE
Apply some hints from hlint

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -54,6 +54,7 @@
 - ignore: {
     name: Use camelCase,
     within: [
+      Language.Finkel.Emit,
       Language.Finkel.Syntax.HBind,
       Language.Finkel.Syntax.HDecl,
       Language.Finkel.Syntax.HExpr,

--- a/finkel-kernel/src/Language/Finkel/Emit.hs
+++ b/finkel-kernel/src/Language/Finkel/Emit.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- | Emit Haskell source code from Haskell AST value.
 --

--- a/finkel-kernel/src/Language/Finkel/Eval.hs
+++ b/finkel-kernel/src/Language/Finkel/Eval.hs
@@ -185,15 +185,10 @@ evalDecls decls = do
 -- | Like 'HscMain.hscDesugar'', but for 'Fnk'.
 fnkcDesugar' :: GhcMonad m => ModLocation -> TcGblEnv -> m ModGuts
 fnkcDesugar' mod_location tc_result = do
-  hsc_env <- getSession
-  r <- ioMsgMaybe (deSugar hsc_env mod_location tc_result)
-
   -- In `Hsc', `handleWarning' is called at this point. But currently Fnk does
   -- not keep tracks of warning messages, so does nothing ...
-  --
-  -- handleWarnings
-
-  return r
+  hsc_env <- getSession
+  ioMsgMaybe (deSugar hsc_env mod_location tc_result)
 
 -- | GHC version compatibility helper for combining 'hscSimplify'
 -- and 'tcg_th_coreplugins'.

--- a/finkel-kernel/src/Language/Finkel/Fnk.hs
+++ b/finkel-kernel/src/Language/Finkel/Fnk.hs
@@ -42,7 +42,6 @@ module Language.Finkel.Fnk
   -- * Debugging
   , FnkDebugFlag(..)
   , fopt
-  , fopt_set
   , setFnkVerbosity
   , debugWhen
   , debugWhen'
@@ -889,10 +888,10 @@ fopt flag fnk_env =
 {-# INLINABLE fopt #-}
 
 -- | Turn on the given 'FnkDebugFlag'.
-fopt_set :: FnkDebugFlag -> FnkEnv -> FnkEnv
-fopt_set flag fnk_env =
+foptSet :: FnkDebugFlag -> FnkEnv -> FnkEnv
+foptSet flag fnk_env =
   fnk_env {envDumpFlags = setBit (envDumpFlags fnk_env) (fromEnum flag)}
-{-# INLINABLE fopt_set #-}
+{-# INLINABLE foptSet #-}
 
 -- | Update the 'envVerbosity' to given value.
 setFnkVerbosity :: Int -> FnkEnv -> FnkEnv
@@ -1052,7 +1051,7 @@ fnkEnvOptions =
   ]
   where
     opt = Option []
-    debug_opt flag = opt [to_str flag] (NoArg (fopt_set flag))
+    debug_opt flag = opt [to_str flag] (NoArg (foptSet flag))
     to_str = map replace . show
     replace '_' = '-'
     replace c   = toLower c

--- a/finkel-kernel/src/Language/Finkel/Form.hs
+++ b/finkel-kernel/src/Language/Finkel/Form.hs
@@ -142,7 +142,7 @@ instance Show Atom where
         _    -> ['#', '\'', c]
       AString _ s -> showsPrec d s
       AInteger il -> showsPrec d (il_value il)
-      AFractional f -> showString (fl_text_compat f)
+      AFractional f -> showString (showFractionalList f)
 
 instance NFData Atom where
   rnf x =

--- a/finkel-kernel/src/Language/Finkel/Form/Fractional.hs
+++ b/finkel-kernel/src/Language/Finkel/Form/Fractional.hs
@@ -3,7 +3,7 @@
 module Language.Finkel.Form.Fractional
   ( FractionalLit(..)
   , mkFractionalLit'
-  , fl_text_compat
+  , showFractionalList
 #if MIN_VERSION_ghc(9,2,0)
   -- XXX: Rename 'fl_value' with 'rationalFromFractionalLit'?
   , fl_value
@@ -63,18 +63,18 @@ mkFractionalLit' x = FL (show (realToFrac x :: Double)) (toRational x)
 #endif
 
 -- | Get string representation of 'FractionalLit'.
-fl_text_compat :: FractionalLit -> String
-{-# INLINE fl_text_compat #-}
+showFractionalList :: FractionalLit -> String
+{-# INLINE showFractionalList #-}
 #if MIN_VERSION_ghc(9,8,0)
-fl_text_compat fl = case fl_text fl of
+showFractionalList fl = case fl_text fl of
   NoSourceText -> error "fractional literal with no source"
   SourceText s -> unpackFS s
 #elif MIN_VERSION_ghc(8,4,0)
-fl_text_compat fl = case fl_text fl of
+showFractionalList fl = case fl_text fl of
   NoSourceText -> error "fractional literal with no source"
   SourceText s -> s
 #else
-fl_text_compat = fl_text
+showFractionalList = fl_text
 #endif
 
 #if MIN_VERSION_ghc(9,2,0)

--- a/finkel-kernel/src/Language/Finkel/Make.hs
+++ b/finkel-kernel/src/Language/Finkel/Make.hs
@@ -289,7 +289,7 @@ makeFromRequire lmname = do
       tr = traceMake fnk_env "makeFromRequire"
       dflags = hsc_dflags hsc_env
 
-  tr ["old summaries:", nvc_or_none old_summaries]
+  tr ["old summaries:", nvcOrNone old_summaries]
   tr ["required module:" <+> ppr (unLoc lmname)]
   tu <- emptyTargetUnit <$> findTargetModuleName dflags lmname
 
@@ -298,7 +298,7 @@ makeFromRequire lmname = do
 
   mgraph <- hsc_mod_graph <$> getSession
   let mod_summaries = mgModSummaries' mgraph
-  tr ["summaries:", nvc_or_none mod_summaries]
+  tr ["summaries:", nvcOrNone mod_summaries]
 
 -- | Make function used when the Finkel compiler was invoked as a ghc plugin.
 makeFromRequirePlugin :: Located ModuleName -> Fnk ()
@@ -377,8 +377,8 @@ makeFromRequirePlugin lmname = do
 #endif
 
   tr [ "target:" <+> ppr target
-     , "old_targets:" <+> nvc_or_none old_targets
-     , "new_targets:" <+> nvc_or_none new_targets
+     , "old_targets:" <+> nvcOrNone old_targets
+     , "new_targets:" <+> nvcOrNone new_targets
      , "hsc_hpt:" <+> pprHPT (hsc_HPT hsc_env)]
 
   setSession (hsc_env {hsc_targets = new_targets})
@@ -429,7 +429,7 @@ make1 how_much old_summaries targets = do
 
   tr [ "total:" <+> text (show total)
      , "targets:", targets_sdoc
-     , "old summaries:", nvc_or_none old_summaries]
+     , "old summaries:", nvcOrNone old_summaries]
 
   hsc_env <- getSession
   (mss0, options) <- summariseTargets hsc_env old_summaries targets
@@ -455,7 +455,7 @@ make1 how_much old_summaries targets = do
                           else extendMG' mg ms
       mgraph0 = foldr updateMG (mkModuleGraph' mss0) old_summaries
 #endif
-  tr ["new summaries:", nvc_or_none (mgModSummaries' mgraph0)]
+  tr ["new summaries:", nvcOrNone (mgModSummaries' mgraph0)]
 
   -- Pass the merged ModuleGraph to the "load'" function, delegate the hard
   -- works to it.

--- a/finkel-kernel/src/Language/Finkel/Make/Recompile.hs
+++ b/finkel-kernel/src/Language/Finkel/Make/Recompile.hs
@@ -347,7 +347,7 @@ checkUsagePackageModules usages = getHscEnv >>= forM_ usages . go
                   Nothing -> outdate mname (text (mname_str ++
                                                   " iface not found"))
                   Just iface ->
-                    when (mi_mod_hash' iface /= old_hash)
+                    when (miModHash' iface /= old_hash)
                          (outdate mname (text (mname_str ++ " hash changed")))
 #if MIN_VERSION_ghc(9,2,0)
               lmws_arg1 = hsc_units
@@ -389,7 +389,7 @@ refillHomeImports fnk_env ms mi = do
       mname = ms_mod_name ms
 
   tr [ "dep_mods mi_deps of" <+> ppr mname
-     , nvc_or_none (dmsToList (mapDMS fst dmods1))
+     , nvcOrNone (dmsToList (mapDMS fst dmods1))
      ]
 
   -- Marking this module as outdated when any of the imported home package
@@ -510,7 +510,7 @@ checkTargetUnit name_and_mb_phase@(lname, _) = do
 checkFlagHash :: HscEnv -> ModSummary -> ModIface -> RecompM ()
 checkFlagHash _he ms iface = do
   -- See "checkFlagHash" function in "MkIface".
-  let old_hash = mi_flag_hash' iface
+  let old_hash = miFlagHash' iface
       dflags0 = ms_hspp_opts ms
       dflags1 = adjustIncludePaths dflags0 ms
       mdl = mi_module iface
@@ -607,16 +607,16 @@ addQuoteInclude' = flip (++)
 #endif
 {-# INLINABLE addQuoteInclude' #-}
 
-mi_mod_hash', mi_flag_hash' :: ModIface -> Fingerprint
+miModHash', miFlagHash' :: ModIface -> Fingerprint
 #if MIN_VERSION_ghc(8,10,0)
-mi_mod_hash' = mi_mod_hash . mi_final_exts
-mi_flag_hash' = mi_flag_hash . mi_final_exts
+miModHash' = mi_mod_hash . mi_final_exts
+miFlagHash' = mi_flag_hash . mi_final_exts
 #else
-mi_mod_hash' = mi_mod_hash
-mi_flag_hash' = mi_flag_hash
+miModHash' = mi_mod_hash
+miFlagHash' = mi_flag_hash
 #endif
-{-# INLINABLE mi_mod_hash' #-}
-{-# INLINABLE mi_flag_hash' #-}
+{-# INLINABLE miModHash' #-}
+{-# INLINABLE miFlagHash' #-}
 
 -- Fields in Dependency module set
 --

--- a/finkel-kernel/src/Language/Finkel/Make/TargetSource.hs
+++ b/finkel-kernel/src/Language/Finkel/Make/TargetSource.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP          #-}
+{-# LANGUAGE BangPatterns  #-}
+{-# LANGUAGE CPP           #-}
+{-# LANGUAGE TupleSections #-}
 -- | Module for source code file path look up.
 module Language.Finkel.Make.TargetSource
   (
@@ -85,7 +86,7 @@ findTargetUnitMaybe
   :: MonadIO m
   => DynFlags -> (Located String, Maybe Phase) -> m (Maybe TargetUnit)
 findTargetUnitMaybe dflags (lpath,mbp) =
-  fmap (\t -> (t, mbp)) <$> findTargetSourceMaybe dflags lpath
+  fmap (, mbp) <$> findTargetSourceMaybe dflags lpath
 
 -- | Get 'ModuleName' from given 'TargetUnit'.
 targetUnitName :: TargetUnit -> ModuleName

--- a/finkel-kernel/src/Language/Finkel/Make/Trace.hs
+++ b/finkel-kernel/src/Language/Finkel/Make/Trace.hs
@@ -3,7 +3,7 @@
 module Language.Finkel.Make.Trace
   ( traceMake
   , traceMake'
-  , nvc_or_none
+  , nvcOrNone
   ) where
 
 #include "ghc_modules.h"
@@ -32,8 +32,8 @@ traceMake' dflags fnk_env fn_name msgs0 =
   in  debugWhen' dflags fnk_env Fnk_trace_make msgs1
 
 -- | Nested 'vcat' or text @"none"@.
-nvc_or_none :: Outputable a => [a] -> SDoc
-nvc_or_none xs = nest 2 sdoc
+nvcOrNone :: Outputable a => [a] -> SDoc
+nvcOrNone xs = nest 2 sdoc
   where
     sdoc =
        if null xs

--- a/finkel-kernel/src/Language/Finkel/Preprocess.hs
+++ b/finkel-kernel/src/Language/Finkel/Preprocess.hs
@@ -282,7 +282,7 @@ defmoduleForDownsweep = Macro (pure . f)
             _                      -> acc
         hasLoadPhase xs =
           case unCode (curve xs) of
-            List ys -> elem (sym ":load") ys
+            List ys -> sym ":load" `elem` ys
             _       -> False
         moduleForm n = mkL0 (List [sym "module", n])
         importForm l xs = LForm (L l (List (sym "import" : map curve xs)))
@@ -404,8 +404,8 @@ ppOptions =
 
 parseBoolish :: String -> Bool
 parseBoolish str
-  | elem low_str trueish = True
-  | elem low_str falsish = False
+  | low_str `elem` trueish = True
+  | low_str `elem` falsish = False
   | otherwise = throw (FinkelException msg)
   where
      low_str = map toLower str

--- a/finkel-kernel/src/Language/Finkel/Syntax/HDecl.hs
+++ b/finkel-kernel/src/Language/Finkel/Syntax/HDecl.hs
@@ -322,9 +322,9 @@ b_gadtD form@(LForm (L l1 _)) (ctxt, bodyty) = do
       ty = lA l1 qty
 #endif
 #if MIN_VERSION_ghc(9,10,0)
-      qty = mkHsQualTy_compat (mkLocatedListA ctxt) bodyty
+      qty = mkHsQualTy' (mkLocatedListA ctxt) bodyty
 #else
-      qty = mkHsQualTy_compat (la2la (mkLocatedListA ctxt)) bodyty
+      qty = mkHsQualTy' (la2la (mkLocatedListA ctxt)) bodyty
 #endif
 #if MIN_VERSION_ghc(9,10,0)
   ldecl <- do
@@ -583,9 +583,9 @@ b_instD mb_overlap (ctxts,ty@(L l _)) decls = do
 #endif
                          }
 #if MIN_VERSION_ghc(9,10,0)
-      qty = L l (mkHsQualTy_compat (mkLocatedListA ctxts) ty)
+      qty = L l (mkHsQualTy' (mkLocatedListA ctxts) ty)
 #else
-      qty = L l (mkHsQualTy_compat (la2la (mkLocatedListA ctxts)) ty)
+      qty = L l (mkHsQualTy' (la2la (mkLocatedListA ctxts)) ty)
 #endif
       instD = InstD NOEXT
       clsInstD = ClsInstD NOEXT
@@ -923,9 +923,9 @@ b_tsigD names (ctxts,typ0) = do
         if null ctxts
           then typ1
 #if MIN_VERSION_ghc(9,10,0)
-          else lA l (mkHsQualTy_compat (mkLocatedListA ctxts) typ1)
+          else lA l (mkHsQualTy' (mkLocatedListA ctxts) typ1)
 #else
-          else lA l (mkHsQualTy_compat (la2la (mkLocatedListA ctxts)) typ1)
+          else lA l (mkHsQualTy' (la2la (mkLocatedListA ctxts)) typ1)
 #endif
       typ1 = unParTy typ0
       mkName form =

--- a/finkel-kernel/src/Language/Finkel/Syntax/HExpr.hs
+++ b/finkel-kernel/src/Language/Finkel/Syntax/HExpr.hs
@@ -250,9 +250,9 @@ b_tsigE (LForm (L l _)) e0 (ctxt,t) =
   let t' = case ctxt of
              [] -> t
 #if MIN_VERSION_ghc(9,10,0)
-             _  -> lA l (mkHsQualTy_compat (mkLocatedListA ctxt) t)
+             _  -> lA l (mkHsQualTy' (mkLocatedListA ctxt) t)
 #else
-             _  -> lA l (mkHsQualTy_compat (la2la (mkLocatedListA ctxt)) t)
+             _  -> lA l (mkHsQualTy' (la2la (mkLocatedListA ctxt)) t)
 #endif
 #if MIN_VERSION_ghc(9,2,0)
       e1 = ExprWithTySig NOEXT e0 (hsTypeToHsSigWcType t')
@@ -347,7 +347,7 @@ mkcfld' (n,mb_e) =
     Just e  -> mkcfld False (n, e)
     Nothing -> mkcfld True (n, punned)
   where
-    punned = lA l (HsVar NOEXT (lN l pun_RDR))
+    punned = lA l (HsVar NOEXT (lN l punRDR))
     l = getLoc n
 {-# INLINABLE mkcfld' #-}
 
@@ -428,7 +428,7 @@ b_integerE (LForm (L l form)) =
       | otherwise      -> return (expr x)
     _                  -> builderError
   where
-    expr x = lA l (hsOverLit $! mkHsIntegral_compat x)
+    expr x = lA l (hsOverLit $! mkHsIntegral' x)
 {-# INLINABLE b_integerE #-}
 
 b_fracE :: Code -> Builder HExpr
@@ -577,7 +577,7 @@ getLocInfo l = withLocInfo l fname mk_int
     -- hpc code coverage will mark the location information as non-evaluated
     -- expressions.
     fname fs = lA ql (hsLit (HsString (toQuotedSourceText fs) fs))
-    mk_int n = lA ql $! hsOverLit $! mkHsIntegral_compat $! mkIntegralLit n
+    mk_int n = lA ql $! hsOverLit $! mkHsIntegral' $! mkIntegralLit n
 #if MIN_VERSION_ghc(9,0,0)
     ql = UnhelpfulSpan (UnhelpfulOther (fsLit "<b_quoteE>"))
 #else

--- a/finkel-kernel/src/Language/Finkel/Syntax/HPat.hs
+++ b/finkel-kernel/src/Language/Finkel/Syntax/HPat.hs
@@ -98,7 +98,7 @@ b_intP (LForm (L l form)) =
     Atom (AInteger n) -> return $! lA l (npat n)
     _                 -> builderError
   where
-    npat n = mkNPat' (L l (mkHsIntegral_compat n))
+    npat n = mkNPat' (L l (mkHsIntegral' n))
 {-# INLINABLE b_intP #-}
 
 b_stringP :: Code -> Builder HPat
@@ -198,7 +198,7 @@ b_labeledP (LForm (L l form)) ps
           case mb_p of
             Just p  -> mkcfld False (lab, p)
             Nothing -> mkcfld True (lab, punned)
-        punned = lA l (VarPat NOEXT (lN l pun_RDR))
+        punned = lA l (VarPat NOEXT (lN l punRDR))
         (wilds, non_wilds) = partitionEithers ps
         mb_dotdot = case wilds of
           []                  -> Nothing

--- a/finkel-kernel/src/Language/Finkel/Syntax/HType.hs
+++ b/finkel-kernel/src/Language/Finkel/Syntax/HType.hs
@@ -299,7 +299,7 @@ b_bangT (LForm (L l _)) t = lA l (hsBangTy srcBang (parTyApp t))
 
 b_forallT :: Code -> ([HTyVarBndrSpecific], ([HType], HType)) -> HType
 b_forallT (LForm (L l0 _)) (bndrs, (ctxts, body)) =
-  let ty0 = lA l0 (mkHsQualTy_compat ctxts' body)
+  let ty0 = lA l0 (mkHsQualTy' ctxts' body)
 #if MIN_VERSION_ghc(9,10,0)
       ctxts' = mkLocatedListA ctxts
 #else
@@ -316,9 +316,9 @@ b_forallT (LForm (L l0 _)) (bndrs, (ctxts, body)) =
 b_qualT :: Code -> ([HType], HType) -> HType
 b_qualT (LForm (L l _)) (ctxts, body) =
 #if MIN_VERSION_ghc(9,10,0)
-  lA l (mkHsQualTy_compat (mkLocatedListA ctxts) body)
+  lA l (mkHsQualTy' (mkLocatedListA ctxts) body)
 #else
-  lA l (mkHsQualTy_compat (la2la (mkLocatedListA ctxts)) body)
+  lA l (mkHsQualTy' (la2la (mkLocatedListA ctxts)) body)
 #endif
 {-# INLINABLE b_qualT #-}
 


### PR DESCRIPTION
Avoid using camel case in top level functions. Remove some unused language pragmas. Use function 'elem' in infix syntax. Use TupleSection instead of lambda function. Add "Language.Finkel.Emit" to the ignored modules of showing "Use camelCase" message.

Remove 'fopt_set' from the list of exported functions in Language.Finkel.Fnk.

Remove some unused functions.