### PR TITLE
Move out some functions from Language.Finkel.Fnk

### DIFF
--- a/finkel-kernel/finkel-kernel.cabal
+++ b/finkel-kernel/finkel-kernel.cabal
@@ -68,6 +68,7 @@ library
                        Language.Finkel.Lexer
                        Language.Finkel.Make
                        Language.Finkel.Main
+                       Language.Finkel.Options
                        Language.Finkel.Plugin
                        Language.Finkel.Preprocess
                        Language.Finkel.Reader
@@ -81,7 +82,6 @@ library
                        Language.Finkel.Make.Summary
                        Language.Finkel.Make.TargetSource
                        Language.Finkel.Make.Trace
-                       Language.Finkel.Options
                        Language.Finkel.ParsedResult
                        Language.Finkel.Syntax.Extension
                        Language.Finkel.Syntax.Location

--- a/finkel-kernel/src/Language/Finkel/Exception.hs
+++ b/finkel-kernel/src/Language/Finkel/Exception.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Exception related types and functions in @finkel-kernel@.
 module Language.Finkel.Exception
@@ -6,26 +7,50 @@ module Language.Finkel.Exception
   , finkelExceptionLoc
   , readOrFinkelException
   , handleFinkelException
+  , printFinkelException
   ) where
 
 #include "ghc_modules.h"
 
 -- base
-import Control.Exception    (Exception (..), throw)
+import Control.Exception            (Exception (..), throw)
+import Control.Monad.IO.Class       (MonadIO (..))
+import System.IO                    (hPutStrLn, stderr)
 
 -- ghc
-import GHC_Types_SrcLoc     (GenLocated (..), SrcSpan)
-import GHC_Utils_Exception  (ExceptionMonad)
+import GHC_Data_Bag                 (unitBag)
+import GHC_Driver_Session           (HasDynFlags (..))
+import GHC_Types_SrcLoc             (GenLocated (..), SrcSpan)
+import GHC_Utils_Exception          (ExceptionMonad)
+import GHC_Utils_Outputable         (neverQualify, text)
+
+#if MIN_VERSION_ghc(9,6,0)
+import GHC.Driver.Errors.Types      (GhcMessage)
+import GHC.Types.Error              (defaultDiagnosticOpts)
+#endif
+
+#if MIN_VERSION_ghc(9,4,0)
+import GHC.Driver.Config.Diagnostic (initDiagOpts)
+import GHC.Driver.Errors            (printMessages)
+import GHC.Types.Error              (mkMessages)
+#else
+import GHC_Driver_Errors            (printBagOfErrors)
+#endif
+
+#if MIN_VERSION_ghc(9,2,0)
+import GHC.Utils.Logger             (HasLogger (..))
+#endif
 
 #if MIN_VERSION_ghc(9,0,0)
 -- exceptions
-import Control.Monad.Catch  (handle)
+import Control.Monad.Catch          (handle)
 #else
 -- ghc
-import GHC_Utils_Exception  (ghandle)
+import GHC_Utils_Exception          (ghandle)
 #endif
 
 -- Internal
+import Language.Finkel.Error
 import Language.Finkel.Form
 
 
@@ -76,6 +101,41 @@ readOrFinkelException what name str =
                                  " for " ++ name ++
                                  ", but got " ++ show str))
 {-# INLINABLE readOrFinkelException #-}
+
+-- | Print 'FinkelException' with source code information when available.
+#if MIN_VERSION_ghc(9,2,0)
+printFinkelException
+  :: (HasLogger m, HasDynFlags m, MonadIO m) => FinkelException -> m ()
+#else
+printFinkelException :: (HasDynFlags m, MonadIO m) => FinkelException -> m ()
+#endif
+printFinkelException e = case finkelExceptionLoc e of
+  Just l  -> prLocErr l
+  Nothing -> pr msg
+  where
+    msg = displayException e
+    pr = liftIO . hPutStrLn stderr
+    prLocErr l = do
+      dflags <- getDynFlags
+      let em = mkWrappedMsg dflags l neverQualify (text msg)
+#if MIN_VERSION_ghc(9,6,0)
+      logger <- getLogger
+      let ghc_msg = mkMessages (unitBag em)
+          diagnostic_opts = defaultDiagnosticOpts @GhcMessage
+          diag_opts = initDiagOpts dflags
+      liftIO (printMessages logger diagnostic_opts diag_opts ghc_msg)
+#elif MIN_VERSION_ghc(9,4,0)
+      logger <- getLogger
+      let ghc_msg = mkMessages (unitBag em)
+      liftIO (printMessages logger (initDiagOpts dflags) ghc_msg)
+#elif MIN_VERSION_ghc(9,2,0)
+      logger <- getLogger
+      liftIO (printBagOfErrors logger dflags (unitBag em))
+#else
+      liftIO (printBagOfErrors dflags (unitBag em))
+#endif
+{-# INLINABLE printFinkelException #-}
+
 
 -- ------------------------------------------------------------------------
 --

--- a/finkel-kernel/src/Language/Finkel/Main.hs
+++ b/finkel-kernel/src/Language/Finkel/Main.hs
@@ -93,6 +93,7 @@ import           GHC.HandleEncoding           (configureHandleEncoding)
 import           Language.Finkel.Exception
 import           Language.Finkel.Fnk
 import           Language.Finkel.Make
+import           Language.Finkel.Options
 import           Language.Finkel.Reader       (supportedLangExts)
 import           Language.Finkel.SpecialForms (defaultFnkEnv)
 import qualified Paths_finkel_kernel

--- a/finkel-kernel/src/Language/Finkel/Preprocess.hs
+++ b/finkel-kernel/src/Language/Finkel/Preprocess.hs
@@ -73,14 +73,14 @@ import GHC_Driver_Session                (HasDynFlags (..))
 import Language.Finkel.Emit              (Hsrc (..), putHsSrc)
 import Language.Finkel.Exception         (FinkelException (..),
                                           handleFinkelException,
+                                          printFinkelException,
                                           readOrFinkelException)
 import Language.Finkel.Expand            (expands, withExpanderSettings)
 import Language.Finkel.Fnk               (FnkEnv (..), FnkEnvRef (..),
                                           FnkInvokedMode (..), Macro (..),
                                           addMacro, lookupMacro, macroFunction,
                                           makeEnvMacros, mergeMacros,
-                                          modifyFnkEnv, printFinkelException,
-                                          runFnk, toGhc)
+                                          modifyFnkEnv, runFnk, toGhc)
 import Language.Finkel.Form              (Form (..), LForm (..), aSymbol,
                                           unCode)
 import Language.Finkel.Make.Summary      (buildHsSyn, withTiming')

--- a/finkel-tool/src/Finkel/Tool/Command/Eval.hs
+++ b/finkel-tool/src/Finkel/Tool/Command/Eval.hs
@@ -20,10 +20,10 @@
    (System.Environment [getProgName])
 
    ;; finkel-kernel
-   (Language.Finkel.Fnk
-    [(Fnk) FnkEnv runFnk fromFnkEnvOptions fnkEnvOptionsUsage])
+   (Language.Finkel.Fnk [(Fnk) FnkEnv runFnk])
    (Language.Finkel.Form [Code])
    (Language.Finkel.Lexer [evalSP])
+   (Language.Finkel.Options [fromFnkEnvOptions fnkEnvOptionsUsage])
    (Language.Finkel.Reader [sexpr])
 
    ;; Internal

--- a/finkel-tool/src/Finkel/Tool/Command/Repl.hs
+++ b/finkel-tool/src/Finkel/Tool/Command/Repl.hs
@@ -25,9 +25,8 @@
 
    ;; finkel-kernel
    (Language.Finkel)
-   (Language.Finkel.Fnk
-    [(FnkEnv ..) EnvMacros fnkEnvOptionsUsage fromFnkEnvOptions
-     makeEnvMacros mergeMacros])
+   (Language.Finkel.Fnk [(FnkEnv ..) EnvMacros makeEnvMacros mergeMacros])
+   (Language.Finkel.Options [fromFnkEnvOptions fnkEnvOptionsUsage])
    (Language.Finkel.SpecialForms [specialForms])
 
    ;; finkel-core

--- a/finkel-tool/src/Finkel/Tool/Command/Run.hs
+++ b/finkel-tool/src/Finkel/Tool/Command/Run.hs
@@ -14,7 +14,8 @@
    (System.Environment [getProgName])
 
    ;; finkel-kernel
-   (Language.Finkel.Fnk [FnkEnv fromFnkEnvOptions fnkEnvOptionsUsage])
+   (Language.Finkel.Fnk [FnkEnv])
+   (Language.Finkel.Options [fromFnkEnvOptions fnkEnvOptionsUsage])
 
    ;; finkel-core
    (Finkel.Core.Functions [make-symbol])

--- a/finkel-tool/src/Finkel/Tool/Internal/Macro/Repl.hs
+++ b/finkel-tool/src/Finkel/Tool/Internal/Macro/Repl.hs
@@ -49,10 +49,9 @@
    (Language.Finkel.Eval [evalExprType evalTypeKind])
    (Language.Finkel.Form [mkLocatedForm])
    (Language.Finkel.Make [buildHsSyn make])
-   (Language.Finkel.Fnk
-    [(FnkEnv ..) fnkEnvOptions getFnkEnv macroNames modifyFnkEnv
-     partitionFnkEnvOptions putFnkEnv setDynFlags setFnkVerbosity
-     updateDynFlags])
+   (Language.Finkel.Fnk [(FnkEnv ..) getFnkEnv macroNames modifyFnkEnv putFnkEnv
+                         setDynFlags setFnkVerbosity updateDynFlags])
+   (Language.Finkel.Options [fnkEnvOptions partitionFnkEnvOptions])
    (Language.Finkel.Syntax [parseExpr parseType])
    (Language.Finkel.Make [asModuleName])
 


### PR DESCRIPTION
Move command line option related functions in Language.Finkel.Fnk to Language.Finkel.Options. Add Language.Finkel.Options to the list of exposed module in cabal configuration.

Move printFinkelException in Language.Finkel.Fnk to Language.Finkel.Exception.

Modify the imports in the modules using the moved functions.