### PR TITLE
Factor out codes for printOrThrowDiagnostics

### DIFF
--- a/finkel-kernel/src/Language/Finkel/Error.hs
+++ b/finkel-kernel/src/Language/Finkel/Error.hs
@@ -1,67 +1,117 @@
-{-# LANGUAGE CPP          #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies     #-}
 -- | Version compatible variant of error message type and functions.
 
 module Language.Finkel.Error
-  ( WrappedMsg
+  (
+    -- * Simple SDoc error message
+    WrappedMsg
   , mkWrappedMsg
   , mkPlainWrappedMsg
+
+    -- * For printing error message
+  , HasLogger(..), Logger, WARNINGs
+  , printLocatedString
+  , printOrThrowDiagnostics'
+
   ) where
 
 #include "ghc_modules.h"
 
-#if MIN_VERSION_ghc(9,6,0)
-import GHC.Types.Error         (NoDiagnosticOpts (..))
-import GHC.Utils.Outputable    (NamePprCtx)
-#else
-import GHC_Utils_Outputable    (PrintUnqualified)
-#endif
+-- base
+import Control.Monad.IO.Class       (MonadIO (..))
 
 #if MIN_VERSION_ghc(9,4,0)
--- base
-import Data.Typeable           (Typeable)
+import Data.Typeable                (Typeable)
+#endif
 
 -- ghc
--- For "instance Diagnostic GhcMessage"
-import GHC.Driver.Errors.Ppr   ()
-import GHC.Driver.Errors.Types (GhcMessage, ghcUnknownMessage)
-import GHC.Types.Error         (Diagnostic (..), DiagnosticReason (..),
-                                mkSimpleDecorated, noHints)
-import GHC.Utils.Error         (MsgEnvelope, mkErrorMsgEnvelope,
-                                mkPlainErrorMsgEnvelope)
+import GHC_Data_Bag                 (unitBag)
+import GHC_Driver_Session           (DynFlags)
+import GHC_Types_SrcLoc             (SrcSpan)
+import GHC_Utils_Outputable         (SDoc, neverQualify, text)
+
+#if MIN_VERSION_ghc(9,8,0)
+import GHC.Driver.Errors            (printOrThrowDiagnostics)
 #elif MIN_VERSION_ghc(9,2,0)
-import GHC.Types.Error         (DecoratedSDoc, MsgEnvelope, mkMsgEnvelope,
-                                mkPlainMsgEnvelope)
+import GHC.Driver.Errors            (handleFlagWarnings)
 #else
-import GHC_Utils_Error         (ErrMsg, mkErrMsg, mkPlainErrMsg)
+import GHC_Driver_Types             (handleFlagWarnings)
 #endif
 
-import GHC_Driver_Session      (DynFlags)
-import GHC_Types_SrcLoc        (SrcSpan)
-import GHC_Utils_Outputable    (SDoc)
+#if MIN_VERSION_ghc(9,8,0)
+import GHC.Driver.Errors.Types      (DriverMessage)
+import GHC.Types.Error              (Messages, defaultDiagnosticOpts)
+#elif MIN_VERSION_ghc(9,0,0)
+import GHC.Driver.CmdLine           (Warn)
+#elif MIN_VERSION_ghc(8,2,0)
+import CmdLineParser                (Warn)
+#else
+import SrcLoc                       (Located)
+#endif
+
+#if MIN_VERSION_ghc(9,6,0)
+import GHC.Types.Error              (NoDiagnosticOpts (..))
+import GHC.Utils.Outputable         (NamePprCtx)
+#else
+import GHC_Utils_Outputable         (PrintUnqualified)
+#endif
 
 #if MIN_VERSION_ghc(9,4,0)
-newtype FnkWrapper = FnkWrapper {unFnkWrapper :: SDoc}
+import GHC.Driver.Config.Diagnostic (initDiagOpts)
+import GHC.Driver.Errors            (printMessages)
+import GHC.Types.Error              (mkMessages)
+#else
+import GHC_Driver_Errors            (printBagOfErrors)
+#endif
+
+#if MIN_VERSION_ghc(9,4,0)
+-- For "instance Diagnostic GhcMessage"
+import GHC.Driver.Errors.Ppr        ()
+import GHC.Driver.Errors.Types      (GhcMessage (..), ghcUnknownMessage)
+import GHC.Types.Error              (Diagnostic (..), DiagnosticReason (..),
+                                     mkSimpleDecorated, noHints)
+import GHC.Utils.Error              (MsgEnvelope, mkErrorMsgEnvelope,
+                                     mkPlainErrorMsgEnvelope)
+#elif MIN_VERSION_ghc(9,2,0)
+import GHC.Types.Error              (DecoratedSDoc, MsgEnvelope, mkMsgEnvelope,
+                                     mkPlainMsgEnvelope)
+#else
+import GHC_Utils_Error              (ErrMsg, mkErrMsg, mkPlainErrMsg)
+#endif
+
+#if MIN_VERSION_ghc(9,2,0)
+import GHC.Utils.Logger             (HasLogger (..), Logger)
+#endif
+
+
+-- ------------------------------------------------------------------------
+-- Wrapper type for SDoc
+-- ------------------------------------------------------------------------
+
+#if MIN_VERSION_ghc(9,4,0)
+newtype SDocWrapper = SDocWrapper {unSDocWrapper :: SDoc}
   deriving (Typeable)
 
-instance Diagnostic FnkWrapper where
+instance Diagnostic SDocWrapper where
 #if MIN_VERSION_ghc(9,6,0)
-  type DiagnosticOpts FnkWrapper = NoDiagnosticOpts
-  diagnosticMessage _no_diagnostic_opts = mkSimpleDecorated . unFnkWrapper
+  type DiagnosticOpts SDocWrapper = NoDiagnosticOpts
+  diagnosticMessage _no_diagnostic_opts = mkSimpleDecorated . unSDocWrapper
 #  if !MIN_VERSION_ghc(9,8,0)
   defaultDiagnosticOpts = NoDiagnosticOpts
 #  endif
   -- XXX: May worth adding Finkel specific diagnostic code.
   diagnosticCode _ = Nothing
 #else
-  diagnosticMessage = mkSimpleDecorated . unFnkWrapper
+  diagnosticMessage = mkSimpleDecorated . unSDocWrapper
 #endif
 
   diagnosticReason = const ErrorWithoutFlag
   diagnosticHints = const noHints
 
 wrapSDoc :: SDoc -> GhcMessage
-wrapSDoc = ghcUnknownMessage . FnkWrapper
+wrapSDoc = ghcUnknownMessage . SDocWrapper
 #endif
 
 -- | Synonym for message with 'SDoc'.
@@ -73,11 +123,11 @@ type WrappedMsg = MsgEnvelope DecoratedSDoc
 type WrappedMsg = ErrMsg
 #endif
 
-#if !MIN_VERSION_ghc(9,6,0)
-#define NamePprCtx PrintUnqualified
-#endif
-
+#if MIN_VERSION_ghc(9,6,0)
 mkWrappedMsg :: DynFlags -> SrcSpan -> NamePprCtx -> SDoc -> WrappedMsg
+#else
+mkWrappedMsg :: DynFlags -> SrcSpan -> PrintUnqualified -> SDoc -> WrappedMsg
+#endif
 {-# INLINABLE mkWrappedMsg #-}
 
 mkPlainWrappedMsg :: DynFlags -> SrcSpan -> SDoc -> WrappedMsg
@@ -92,4 +142,65 @@ mkPlainWrappedMsg = const mkPlainMsgEnvelope
 #else
 mkWrappedMsg = mkErrMsg
 mkPlainWrappedMsg = mkPlainErrMsg
+#endif
+
+
+-- ------------------------------------------------------------------------
+-- For printing error messages
+-- ------------------------------------------------------------------------
+
+printLocatedString
+  :: MonadIO m => Logger -> DynFlags -> SrcSpan -> String -> m ()
+printLocatedString _logger dflags l str = do
+      let em = mkWrappedMsg dflags l neverQualify (text str)
+#if MIN_VERSION_ghc(9,6,0)
+      let ghc_msg = mkMessages (unitBag em)
+          diagnostic_opts = defaultDiagnosticOpts @GhcMessage
+          diag_opts = initDiagOpts dflags
+      liftIO (printMessages _logger diagnostic_opts diag_opts ghc_msg)
+#elif MIN_VERSION_ghc(9,4,0)
+      let ghc_msg = mkMessages (unitBag em)
+      liftIO (printMessages _logger (initDiagOpts dflags) ghc_msg)
+#elif MIN_VERSION_ghc(9,2,0)
+      liftIO (printBagOfErrors _logger dflags (unitBag em))
+#else
+      liftIO (printBagOfErrors dflags (unitBag em))
+#endif
+{-# INLINABLE printLocatedString #-}
+
+#if MIN_VERSION_ghc(9,8,0)
+type WARNINGs = Messages DriverMessage
+#elif MIN_VERSION_ghc(8,2,0)
+type WARNINGs = [Warn]
+#else
+type WARNINGs = [Located String]
+#endif
+
+-- GHC.Utils.Logger did not exist until ghc 9.2.
+#if !MIN_VERSION_ghc(9,2,0)
+class HasLogger m where
+  getLogger :: m Logger
+
+data Logger -- should never constructed.
+#endif
+
+-- | Version compatibility function for 'printOrThrowDiagnostics', former
+-- @handleFlagWarnings@ function.
+printOrThrowDiagnostics' :: MonadIO m => Logger -> DynFlags -> WARNINGs -> m ()
+printOrThrowDiagnostics' _logger dflags warns = do
+#if MIN_VERSION_ghc(9,8,0)
+  let diagnostic_opts = defaultDiagnosticOpts @GhcMessage
+      diag_opts = initDiagOpts dflags
+      msg = GhcDriverMessage <$> warns
+  liftIO $ printOrThrowDiagnostics _logger diagnostic_opts diag_opts msg
+#elif MIN_VERSION_ghc(9,6,0)
+  let diagnostic_opts = defaultDiagnosticOpts @GhcMessage
+      diag_opts = initDiagOpts dflags
+  liftIO $ handleFlagWarnings _logger diagnostic_opts diag_opts warns
+#elif MIN_VERSION_ghc(9,4,0)
+  liftIO $ handleFlagWarnings _logger (initDiagOpts dflags) warns
+#elif MIN_VERSION_ghc(9,2,0)
+  liftIO $ handleFlagWarnings _logger dflags warns
+#else
+  liftIO $ handleFlagWarnings dflags warns
 #endif

--- a/finkel-kernel/src/Language/Finkel/Exception.hs
+++ b/finkel-kernel/src/Language/Finkel/Exception.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE CPP              #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE CPP #-}
 
 -- | Exception related types and functions in @finkel-kernel@.
 module Language.Finkel.Exception
@@ -13,40 +12,21 @@ module Language.Finkel.Exception
 #include "ghc_modules.h"
 
 -- base
-import Control.Exception            (Exception (..), throw)
-import Control.Monad.IO.Class       (MonadIO (..))
-import System.IO                    (hPutStrLn, stderr)
+import Control.Exception      (Exception (..), throw)
+import Control.Monad.IO.Class (MonadIO (..))
+import System.IO              (hPutStrLn, stderr)
 
 -- ghc
-import GHC_Data_Bag                 (unitBag)
-import GHC_Driver_Session           (HasDynFlags (..))
-import GHC_Types_SrcLoc             (GenLocated (..), SrcSpan)
-import GHC_Utils_Exception          (ExceptionMonad)
-import GHC_Utils_Outputable         (neverQualify, text)
-
-#if MIN_VERSION_ghc(9,6,0)
-import GHC.Driver.Errors.Types      (GhcMessage)
-import GHC.Types.Error              (defaultDiagnosticOpts)
-#endif
-
-#if MIN_VERSION_ghc(9,4,0)
-import GHC.Driver.Config.Diagnostic (initDiagOpts)
-import GHC.Driver.Errors            (printMessages)
-import GHC.Types.Error              (mkMessages)
-#else
-import GHC_Driver_Errors            (printBagOfErrors)
-#endif
-
-#if MIN_VERSION_ghc(9,2,0)
-import GHC.Utils.Logger             (HasLogger (..))
-#endif
+import GHC_Driver_Session     (HasDynFlags (..))
+import GHC_Types_SrcLoc       (GenLocated (..), SrcSpan)
+import GHC_Utils_Exception    (ExceptionMonad)
 
 #if MIN_VERSION_ghc(9,0,0)
 -- exceptions
-import Control.Monad.Catch          (handle)
+import Control.Monad.Catch    (handle)
 #else
 -- ghc
-import GHC_Utils_Exception          (ghandle)
+import GHC_Utils_Exception    (ghandle)
 #endif
 
 -- Internal
@@ -103,39 +83,16 @@ readOrFinkelException what name str =
 {-# INLINABLE readOrFinkelException #-}
 
 -- | Print 'FinkelException' with source code information when available.
-#if MIN_VERSION_ghc(9,2,0)
 printFinkelException
   :: (HasLogger m, HasDynFlags m, MonadIO m) => FinkelException -> m ()
-#else
-printFinkelException :: (HasDynFlags m, MonadIO m) => FinkelException -> m ()
-#endif
 printFinkelException e = case finkelExceptionLoc e of
-  Just l  -> prLocErr l
-  Nothing -> pr msg
+  Nothing -> liftIO $ hPutStrLn stderr msg
+  Just l  -> do
+    logger <- getLogger
+    dflags <- getDynFlags
+    printLocatedString logger dflags l msg
   where
     msg = displayException e
-    pr = liftIO . hPutStrLn stderr
-    prLocErr l = do
-      dflags <- getDynFlags
-      let em = mkWrappedMsg dflags l neverQualify (text msg)
-#if MIN_VERSION_ghc(9,6,0)
-      logger <- getLogger
-      let ghc_msg = mkMessages (unitBag em)
-          diagnostic_opts = defaultDiagnosticOpts @GhcMessage
-          diag_opts = initDiagOpts dflags
-      liftIO (printMessages logger diagnostic_opts diag_opts ghc_msg)
-#elif MIN_VERSION_ghc(9,4,0)
-      logger <- getLogger
-      let ghc_msg = mkMessages (unitBag em)
-      liftIO (printMessages logger (initDiagOpts dflags) ghc_msg)
-#elif MIN_VERSION_ghc(9,2,0)
-      logger <- getLogger
-      liftIO (printBagOfErrors logger dflags (unitBag em))
-#else
-      liftIO (printBagOfErrors dflags (unitBag em))
-#endif
-{-# INLINABLE printFinkelException #-}
-
 
 -- ------------------------------------------------------------------------
 --
@@ -150,3 +107,4 @@ handleFinkelException = handle
 #else
 handleFinkelException = ghandle
 #endif
+

--- a/finkel-kernel/src/Language/Finkel/Fnk.hs
+++ b/finkel-kernel/src/Language/Finkel/Fnk.hs
@@ -158,7 +158,6 @@ import           GHC.Driver.Make           (ModIfaceCache, newIfaceCache)
 
 #if MIN_VERSION_ghc(9,2,0)
 import           GHC.Driver.Env            (hsc_units)
-import           GHC.Utils.Logger          (HasLogger (..))
 #else
 import           GHC_Driver_Session        (HscTarget (..))
 #endif
@@ -186,6 +185,7 @@ import qualified Data.IntSet               as EnumSet
 #endif
 
 -- Internal
+import           Language.Finkel.Error
 import           Language.Finkel.Exception
 import           Language.Finkel.Form
 
@@ -430,6 +430,9 @@ instance HasDynFlags Fnk where
 instance HasLogger Fnk where
   getLogger = Fnk (const getLogger)
   {-# INLINE getLogger #-}
+#else
+instance HasLogger Fnk where
+  getLogger = pure (error "getLogger (Fnk): no Logger")
 #endif
 
 instance GhcMonad Fnk where

--- a/finkel-kernel/src/Language/Finkel/Make/Recompile.hs
+++ b/finkel-kernel/src/Language/Finkel/Make/Recompile.hs
@@ -119,6 +119,7 @@ import           GHC_Driver_Session                (IncludeSpecs,
 #endif
 
 -- internal
+import           Language.Finkel.Error
 import           Language.Finkel.Fnk
 import           Language.Finkel.Make.Summary
 import           Language.Finkel.Make.TargetSource
@@ -232,6 +233,14 @@ instance MonadIO RecompM where
 instance HasDynFlags RecompM where
   getDynFlags = RecompM (\st -> pure (Right (hsc_dflags (rs_hsc_env st)), st))
   {-# INLINE getDynFlags #-}
+
+instance HasLogger RecompM where
+#if MIN_VERSION_ghc(9,2,0)
+  getLogger = RecompM (\st -> pure (Right (hsc_logger (rs_hsc_env st)), st))
+  {-# INLINE getLogger #-}
+#else
+  getLogger = pure (error "getLogger (RecompM): no Logger")
+#endif
 
 -- | Check whether recompilation is required.
 checkRecompileRequired

--- a/finkel-kernel/src/Language/Finkel/Make/TargetSource.hs
+++ b/finkel-kernel/src/Language/Finkel/Make/TargetSource.hs
@@ -56,7 +56,7 @@ import GHC_Types_SrcLoc       (GenLocated (..), Located)
 import GHC_Unit_Module        (ModuleName, mkModuleName, moduleNameSlashes,
                                moduleNameString)
 import GHC_Utils_Misc         (looksLikeModuleName)
-import GHC_Utils_Outputable   (Outputable (..), neverQualify, sep, text)
+import GHC_Utils_Outputable   (Outputable (..), sep, text)
 
 -- Internal
 import Language.Finkel.Error
@@ -244,10 +244,9 @@ findTargetSourceWithPragma pragma dflags (L l modNameOrFilePath)= do
           modName = mkModuleName (asModuleName path)
   case mb_inputPath of
     Just path -> detectSource path
-    Nothing   -> do
-      let err = mkWrappedMsg dflags l neverQualify doc
-          doc = text ("cannot find target source: " ++ modNameOrFilePath)
-      throwOneError err
+    Nothing   ->
+      let doc = text ("cannot find target source: " ++ modNameOrFilePath)
+      in  throwOneError (mkPlainWrappedMsg dflags l doc)
 
 
 -- ------------------------------------------------------------------------

--- a/finkel-tool/src/Finkel/Tool/Internal/Eval.hs
+++ b/finkel-tool/src/Finkel/Tool/Internal/Eval.hs
@@ -179,9 +179,8 @@ See \"GHCi.UI\", \"GHCi.UI.Monad\", and \"ghc/Main.hs\"."
 
 (defn (:: parse-dynamic-flags
         (=> (MonadIO m)
-            (-> HscEnv
-                [Located String]
-                (m (, DynFlags [Located String] WARN)))))
+            (-> HscEnv [Located String]
+                (m (, DynFlags [Located String] WARNINGs)))))
   [hsc-env]
   (cond-expand
     [(<= 902 :ghc)
@@ -507,7 +506,7 @@ to separate object files from source code files."
   (lept [emsgs (srcErrorMessages src-err)
          sdoc (vcat (ppr-wrapped-msg-bag-with-loc emsgs))]
     (do (<- dflags getDynFlags)
-        (<- unqual get-name-ppr-ctx %_getPrintUnqual)
+        (<- unqual get-name-ppr-ctx)
         (return (render-with-err-style dflags unqual sdoc)))))
 
 (defn (:: make-finkel-exception-message (-> FinkelException (Fnk String)))


### PR DESCRIPTION
Add and export version compatible variant of "printOrThrowDiagnostics" to Language.Finkel.Error. Reuse in finkel-kernel and finkel-tool packages.

Add dummy HasLogger class to support old ghc versions without the type class. Make Fnk and RecompM as instances of HasLogger.

Move out the body codes of "printFinkelException" to Language.Finkel.Error, to decrease the total amount of module imports from ghc package.

Rename "FnkWrapper" to "SDocWrapper", since the wrapper simpliy wraps SDoc.

Some minor tidy up.