### PR TITLE
Remove upper bounds of Cabal dependency in test packages

### DIFF
--- a/finkel-setup/test/data/p01/p01.cabal
+++ b/finkel-setup/test/data/p01/p01.cabal
@@ -15,7 +15,7 @@ extra-source-files:  src/P01/*.fnk
 
 custom-setup
   setup-depends:       base  >= 4.7 && < 5
-                     , Cabal >= 2.0 && < 3.9
+                     , Cabal >= 2.0
                      , finkel-setup
 
 library

--- a/finkel-setup/test/data/p02/p02.cabal
+++ b/finkel-setup/test/data/p02/p02.cabal
@@ -11,7 +11,7 @@ extra-doc-files: CHANGELOG.md
 
 custom-setup
   setup-depends: base  >= 4.14 && < 5
-               , Cabal >= 3.2  && < 3.12
+               , Cabal >= 3.2
                , finkel-setup
 
 common warnings


### PR DESCRIPTION
Modify cabal configuration file for projects used in finkel-setup tests, remove the upper version bound from "Cabal" package dependency.