### PR TITLE
Suppress warning messages in syntax tests

### DIFF
--- a/finkel-kernel/test/data/syntax/1004-doccomment-01.fnk
+++ b/finkel-kernel/test/data/syntax/1004-doccomment-01.fnk
@@ -103,10 +103,7 @@ containing type class constraints. This documentation comment includes
 (:doc "Documentation for data type 'D1'.")
 (data (D1 a b)
   (D1a a)
-  (:doc^ "Documentation for 'D1a'.")
-
-  (D1b %p(UNPACK) !b)
-  (:doc^ "Documentation for 'D1b'.
+  (:doc^ "Documentation for 'D1a'.
 
 This comment contains empty lines.
 

--- a/finkel-kernel/test/data/syntax/1004-doccomment-03.fnk
+++ b/finkel-kernel/test/data/syntax/1004-doccomment-03.fnk
@@ -1,0 +1,25 @@
+;;; Doccomment with unusable UNPACK pragma
+
+(module Main)
+
+(:doc "Documentation for data type 'D1'.")
+(data (D1 a b)
+  (D1a a)
+  (:doc^ "Documentation for 'D1a'.")
+
+  (D1b %p(UNPACK) !b)
+  (:doc^ "Documentation for 'D1b', has unusable UNPACK pragma.
+
+This comment contains empty lines.
+
+A line containing some foo: Foo foo foo foo, foo foo, and foo.")
+
+  (D1ab a (:doc^ "The first argument 'D1ab.")
+        b (:doc^ "The 2nd.")
+        Int (:doc^ "The 3rd."))
+
+  (deriving Show))
+
+(:: main (IO ()))
+(= main
+  (print [(D1a True) (D1b False)]))

--- a/finkel-kernel/test/data/syntax/2005-gadts-01.fnk
+++ b/finkel-kernel/test/data/syntax/2005-gadts-01.fnk
@@ -30,9 +30,9 @@
 ;; GADTs with UNPACK pragmas.
 
 (data (G2 a)
-  (:: G2a (-> %p(UNPACK) !(Maybe a) (G2 a)))
+  (:: G2a (-> !(Maybe a) (G2 a)))
   (:: G2b (-> %p(UNPACK) !Int (G2 Int)))
-  (:: G2c (-> %p(UNPACK) !a %p(UNPACK) !Int (G2 a))))
+  (:: G2c (-> !a %p(UNPACK) !Int (G2 a))))
 
 (instance (=> (Show a) (Show (G2 a)))
   (= show (G2a a) (concat ["G2a (" (show a) ")"]))

--- a/finkel-kernel/test/data/syntax/2005-gadts-02.fnk
+++ b/finkel-kernel/test/data/syntax/2005-gadts-02.fnk
@@ -1,0 +1,24 @@
+;;;  GADTs with unusable UNPACK pragmas.
+
+%p(LANGUAGE GADTs)
+
+(module Main)
+
+(data (G2 a)
+  (:: G2a (-> %p(UNPACK) !(Maybe a) (G2 a)))
+  (:: G2b (-> %p(UNPACK) !Int (G2 Int)))
+  (:: G2c (-> %p(UNPACK) !a %p(UNPACK) !Int (G2 a))))
+
+(instance (=> (Show a) (Show (G2 a)))
+  (= show (G2a a) (concat ["G2a (" (show a) ")"]))
+  (= show (G2b a) (concat ["G2b (" (show a) ")"]))
+  (= show (G2c a b) (concat ["G2c (" (show a) " " (show b) ")"])))
+
+(:: gadt2 (-> Int (IO ())))
+(= gadt2 n
+  (do (print (G2a (Just #'x)))
+      (print (G2b n))
+      (print (G2c n 43))))
+
+(:: main (IO ()))
+(= main (gadt2 42))

--- a/finkel-kernel/test/data/syntax/2008-options.fnk
+++ b/finkel-kernel/test/data/syntax/2008-options.fnk
@@ -1,6 +1,5 @@
 ;;;; OPTIONS_GHC and OPTIONS_HADDOCK pragma.
 
-%p(OPTIONS_GHC -fcse)
 %p(LANGUAGE DeriveFoldable)
 %p(OPTIONS_GHC -Wall)
 %p(LANGUAGE DeriveFunctor)

--- a/finkel-kernel/test/data/syntax/2010-kindsig.fnk
+++ b/finkel-kernel/test/data/syntax/2010-kindsig.fnk
@@ -15,7 +15,8 @@
   (KS2 [a]))
 
 (newtype (KS3 (:: m (-> Type Type)) a)
-  (KS3 [a]))
+  (KS3 [a])
+  (deriving Show))
 
 (type (KS4 (:: f (-> Type Type)))
   (f Int))
@@ -41,8 +42,7 @@
         (KS1 xs) (print xs))
       (case (KS2 [(:: 4 Int) 5 6])
         (KS2 xs) (print xs))
-      (case (KS3 [(:: 7 Int) 8 9])
-        (KS3 xs) (print xs))
+      (print (KS3 [(:: 7 Int) 8 9]))
       (print (:: (Just 42) (KS4 Maybe)))
       (print (f_ks1 41))
       (print (f_ks2 "f_ks2"))

--- a/finkel-kernel/test/data/syntax/2011-scoped.fnk
+++ b/finkel-kernel/test/data/syntax/2011-scoped.fnk
@@ -31,14 +31,17 @@
     (= ys (reverse xs))))
 
 (class (STVC a)
-  (:: stv_op (-> [a] a))
+  (:: stv_op (-> [a] (Maybe a)))
   (= stv_op xs
-    (let ((:: ys [a])
-          (= ys (reverse xs)))
-      (head ys))))
+    (case (reverse xs)
+      (: x _) (Just x)
+      [] Nothing)))
 
 (instance (=> (STVC b) (STVC [b]))
-  (= stv_op xs (reverse (head (:: xs [[b]])))))
+  (= stv_op xs
+    (case (:: xs [[b]])
+      (: ys _) (Just (reverse ys))
+      [] Nothing)))
 
 (instance (STVC Bool))
 


### PR DESCRIPTION
Warning messages are shown as annotations in github workflow, modify the syntax tests to suppress warnings to make the annotations less noisy.

Add list of options with ghc version condition to add flags for certain syntax tests to ignore warning messages when running syntax tests.

Rewrite doccomment and GADT syntax test, move out the codes using unusable UNPACK pragma.

Remove "-fcse" ghc file local option, to avoid warning mentioning the use of optimization option is meaningless in interpreter.

Rewrite codes to avoid using the `head' function, to avoid warning message saying that the head is a partial function.