### PR TITLE
Modify block comment syntax to {- ... -}

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -283,7 +283,7 @@ class FinkelLexer(RegexLexer):
             (r'%p\(.*', token.Comment),
 
             # Comment:
-            (r'#\;', Comment.Multiline, 'multiline-comment'),
+            (r'{-', Comment.Multiline, 'multiline-comment'),
             (r';.*', Comment.Single),
             (r'%_', Comment.Single),
 
@@ -411,10 +411,10 @@ class FinkelLexer(RegexLexer):
         ],
 
         'multiline-comment': [
-            (r'#\;', Comment.Multiline, '#push'),
-            (r'\;#', Comment.Multiline, '#pop'),
-            (r'[^;#]+', Comment.Multiline),
-            (r'[;#]', Comment.Multiline),
+            (r'{-', Comment.Multiline, '#push'),
+            (r'-}', Comment.Multiline, '#pop'),
+            (r'[^-}]+', Comment.Multiline),
+            (r'[-}]', Comment.Multiline),
         ]
     }
 

--- a/doc/contents/language-syntax.rst
+++ b/doc/contents/language-syntax.rst
@@ -30,7 +30,7 @@ Line contents after ``;`` are treated as comments.
 .. literalinclude:: ../include/language-syntax/expr/line-comment.hs
    :language: haskell
 
-Block style comment is supported with ``#;`` and ``;#``.
+Block style comment is supported with ``{-`` and ``-}``.
 
 .. literalinclude:: ../include/language-syntax/expr/block-comment.fnk
    :language: finkel

--- a/doc/include/language-syntax/expr/block-comment.fnk
+++ b/doc/include/language-syntax/expr/block-comment.fnk
@@ -1,1 +1,1 @@
-(putStrLn #;Finkel block comment;# "bar")
+(putStrLn {- Finkel block comment -} "bar")

--- a/finkel-kernel/src/Language/Finkel/Lexer.x
+++ b/finkel-kernel/src/Language/Finkel/Lexer.x
@@ -126,7 +126,7 @@ $white+  ;
 \;+ $white+ \$ @hsymbol $white_no_nl* ~$nl* @contdoc* { tok_doc_named }
 
 \; .*    { tok_line_comment }
-\#\; .*  { tok_block_comment }
+\{\- .*  { tok_block_comment }
 
 --- Discard prefix
 \% \_ { tok_discard }
@@ -518,8 +518,8 @@ tok_block_comment_with :: (String -> Token)
                        -> Action
 tok_block_comment_with tok ini inp0 _ = do
   case alexGetChar inp0 of
-    Just ('#', inp1)
-      | Just (';', inp2) <- alexGetChar inp1
+    Just ('{', inp1)
+      | Just ('-', inp2) <- alexGetChar inp1
       , Just (c, inp3) <- ini inp2
       , Just (com, inp4) <- go inp3 c ""
       -> alexSetInput inp4 >> return (tok (reverse com))
@@ -527,7 +527,7 @@ tok_block_comment_with tok ini inp0 _ = do
   where
     go inp prev acc =
       case alexGetChar inp of
-        Just (c, inp') | prev == ';', c == '#', _:tl <- acc -> Just (tl, inp')
+        Just (c, inp') | prev == '-', c == '}', _:tl <- acc -> Just (tl, inp')
                        | otherwise -> go inp' c (c:acc)
         Nothing -> Nothing
 {-# INLINABLE tok_block_comment_with #-}

--- a/finkel-kernel/test/data/syntax/1000-comment.fnk
+++ b/finkel-kernel/test/data/syntax/1000-comment.fnk
@@ -16,7 +16,7 @@
 
 (module Main)
 
-#;
+{-
 
 Sample block comment. All literals between character sequence `#' `|',
 and `|' `#' are block comment. Block comments understand UNICODE
@@ -26,7 +26,7 @@ characters:
 - ฉันกินกระจกได้ แต่มันไม่ทำให้ฉันเจ็บ
 - მინას ვჭამ და არა მტკივა.
 
-;#
+-}
 
 ;;; * The main function
 
@@ -57,7 +57,7 @@ characters:
 
 (= foo-aux putStrLn)
 
-#;onelineblockcommentwithoutspaces;#
+{-onelineblockcommentwithoutspaces-}
 
 ;;; ** The bar function
 
@@ -80,8 +80,8 @@ characters:
             Int                 ; ^ Arg 2.
             (IO ())))
 (= bar a b
-  (putStrLn #;more;#
-   (++ #;block;# "From bar: " #;comments;# (show (+ a b)))))
+  (putStrLn {-more-}
+   (++ {-block-} "From bar: " {-comments-} (show (+ a b)))))
 
 ;;; ** The buzz function
 


### PR DESCRIPTION
Modify block comment syntax in lexer from #; ... ;# to {- ... -}, as appear in Haskell. Update block comment syntax in tests and documentations.