### PR TITLE
mv Language.Finkel.Syntax.{SynUtils,Utils}.hs

### DIFF
--- a/finkel-kernel/finkel-kernel.cabal
+++ b/finkel-kernel/finkel-kernel.cabal
@@ -83,7 +83,7 @@ library
                        Language.Finkel.ParsedResult
                        Language.Finkel.Syntax.Extension
                        Language.Finkel.Syntax.Location
-                       Language.Finkel.Syntax.SynUtils
+                       Language.Finkel.Syntax.Utils
                        Language.Finkel.Syntax.HBind
                        Language.Finkel.Syntax.HDecl
                        Language.Finkel.Syntax.HExpr

--- a/finkel-kernel/src/Language/Finkel/SpecialForms.hs
+++ b/finkel-kernel/src/Language/Finkel/SpecialForms.hs
@@ -112,7 +112,7 @@ import Language.Finkel.Make              (findTargetModuleNameMaybe,
 import Language.Finkel.Make.TargetSource (targetSourcePath)
 import Language.Finkel.Syntax            (parseExpr, parseLImport,
                                           parseModuleNoHeader)
-import Language.Finkel.Syntax.SynUtils
+import Language.Finkel.Syntax.Utils
 
 
 -- ---------------------------------------------------------------------

--- a/finkel-kernel/src/Language/Finkel/Syntax.y
+++ b/finkel-kernel/src/Language/Finkel/Syntax.y
@@ -56,7 +56,7 @@ import Language.Finkel.Syntax.HExpr
 import Language.Finkel.Syntax.HImpExp
 import Language.Finkel.Syntax.HPat
 import Language.Finkel.Syntax.HType
-import Language.Finkel.Syntax.SynUtils
+import Language.Finkel.Syntax.Utils
 }
 
 %name parse_module module

--- a/finkel-kernel/src/Language/Finkel/Syntax/HBind.hs
+++ b/finkel-kernel/src/Language/Finkel/Syntax/HBind.hs
@@ -7,31 +7,31 @@ module Language.Finkel.Syntax.HBind where
 #include "ghc_modules.h"
 
 -- ghc
-import           GHC_Data_Bag                    (listToBag)
-import           GHC_Data_OrdList                (toOL)
-import           GHC_Hs_Binds                    (FixitySig (..), HsBind,
-                                                  HsBindLR (..),
-                                                  HsLocalBindsLR (..),
-                                                  HsValBindsLR (..), Sig (..),
-                                                  emptyLocalBinds)
-import           GHC_Hs_Decls                    (HsDecl (..))
-import           GHC_Hs_Expr                     (GRHSs (..), LGRHS)
-import qualified GHC_Parser_PostProcess          as PostProcess
-import           GHC_Types_Fixity                (Fixity)
-import           GHC_Types_Name_Reader           (RdrName)
-import           GHC_Types_SrcLoc                (GenLocated (..))
+import           GHC_Data_Bag                 (listToBag)
+import           GHC_Data_OrdList             (toOL)
+import           GHC_Hs_Binds                 (FixitySig (..), HsBind,
+                                               HsBindLR (..),
+                                               HsLocalBindsLR (..),
+                                               HsValBindsLR (..), Sig (..),
+                                               emptyLocalBinds)
+import           GHC_Hs_Decls                 (HsDecl (..))
+import           GHC_Hs_Expr                  (GRHSs (..), LGRHS)
+import qualified GHC_Parser_PostProcess       as PostProcess
+import           GHC_Types_Fixity             (Fixity)
+import           GHC_Types_Name_Reader        (RdrName)
+import           GHC_Types_SrcLoc             (GenLocated (..))
 
 #if MIN_VERSION_ghc(9,10,0)
-import           GHC_Hs_Binds                    (HsMultAnn (..))
+import           GHC_Hs_Binds                 (HsMultAnn (..))
 #endif
 
 #if !MIN_VERSION_ghc(9,2,0)
-import           GHC_Types_SrcLoc                (SrcSpan)
+import           GHC_Types_SrcLoc             (SrcSpan)
 #endif
 
 -- Internal
 import           Language.Finkel.Builder
-import           Language.Finkel.Syntax.SynUtils
+import           Language.Finkel.Syntax.Utils
 
 
 mkPatBind_compat :: HPat -> [HGRHS] -> [HDecl] -> HsBind PARSED

--- a/finkel-kernel/src/Language/Finkel/Syntax/HDecl.hs
+++ b/finkel-kernel/src/Language/Finkel/Syntax/HDecl.hs
@@ -104,7 +104,7 @@ import Language.Finkel.Data.SourceText
 import Language.Finkel.Form
 import Language.Finkel.Syntax.HBind
 import Language.Finkel.Syntax.HType
-import Language.Finkel.Syntax.SynUtils
+import Language.Finkel.Syntax.Utils
 
 
 -- ---------------------------------------------------------------------

--- a/finkel-kernel/src/Language/Finkel/Syntax/HExpr.hs
+++ b/finkel-kernel/src/Language/Finkel/Syntax/HExpr.hs
@@ -99,7 +99,7 @@ import Language.Finkel.Data.SourceText
 import Language.Finkel.Form
 import Language.Finkel.Syntax.HBind
 import Language.Finkel.Syntax.HType
-import Language.Finkel.Syntax.SynUtils
+import Language.Finkel.Syntax.Utils
 
 
 -- ---------------------------------------------------------------------

--- a/finkel-kernel/src/Language/Finkel/Syntax/HImpExp.hs
+++ b/finkel-kernel/src/Language/Finkel/Syntax/HImpExp.hs
@@ -36,7 +36,7 @@ import Language.Haskell.Syntax.ImpExp   (ImportListInterpretation (..))
 -- Internal
 import Language.Finkel.Builder
 import Language.Finkel.Form
-import Language.Finkel.Syntax.SynUtils
+import Language.Finkel.Syntax.Utils
 
 -- ---------------------------------------------------------------------
 --

--- a/finkel-kernel/src/Language/Finkel/Syntax/HPat.hs
+++ b/finkel-kernel/src/Language/Finkel/Syntax/HPat.hs
@@ -54,7 +54,7 @@ import GHC_Hs_Utils                    (mkLHsSigWcType)
 import Language.Finkel.Builder
 import Language.Finkel.Data.FastString (nullFS, unconsFS)
 import Language.Finkel.Form
-import Language.Finkel.Syntax.SynUtils
+import Language.Finkel.Syntax.Utils
 
 
 -- ------------------------------------------------------------------------

--- a/finkel-kernel/src/Language/Finkel/Syntax/HType.hs
+++ b/finkel-kernel/src/Language/Finkel/Syntax/HType.hs
@@ -64,7 +64,7 @@ import GHC_Types_Var                   (ForallVisFlag (..))
 import Language.Finkel.Builder
 import Language.Finkel.Data.FastString (lengthFS, nullFS, unconsFS)
 import Language.Finkel.Form
-import Language.Finkel.Syntax.SynUtils
+import Language.Finkel.Syntax.Utils
 
 -- ---------------------------------------------------------------------
 --

--- a/finkel-kernel/src/Language/Finkel/Syntax/Utils.hs
+++ b/finkel-kernel/src/Language/Finkel/Syntax/Utils.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE CPP #-}
 
 -- | Utility codes for syntax.
-module Language.Finkel.Syntax.SynUtils
+module Language.Finkel.Syntax.Utils
   ( -- * This module
-    module Language.Finkel.Syntax.SynUtils
+    module Language.Finkel.Syntax.Utils
 
     -- * Extension module
   , module Language.Finkel.Syntax.Extension
@@ -220,7 +220,7 @@ cfld2ufld (L l0 (HsRecField (L l1 (FieldOcc _ rdr)) arg pun)) =
   where
     unambiguous = Unambiguous unused rdr
 #  if !MIN_VERSION_ghc(9,0,0)
-cfld2ufld _ = error "Language.Finkel.Syntax.SynUtils:cfld2ufld"
+cfld2ufld _ = error "Language.Finkel.Syntax.Utils:cfld2ufld"
 #  endif
 #endif
 {-# INLINABLE cfld2ufld #-}
@@ -341,35 +341,35 @@ codeToUserTyVar code =
     LForm (L l (Atom (ASymbol name))) ->
       let bvis = HsBndrRequired unused
       in lA l (UserTyVar unused bvis (lN l (mkUnqual tvName name)))
-    _ -> error "Language.Finkel.Syntax.SynUtils:codeToUserTyVar"
+    _ -> error "Language.Finkel.Syntax.Utils:codeToUserTyVar"
 codeToUserTyVarSpecific :: Code -> LHsTyVarBndr Specificity PARSED
 codeToUserTyVarSpecific code =
   case code of
     LForm (L l (Atom (ASymbol name))) ->
       lA l (UserTyVar unused SpecifiedSpec (lN l (mkUnqual tvName name)))
       -- XXX: Does not support 'InferredSpec' yet.
-    _ -> error "Language.Finkel.Syntax.SynUtils:codeToUserTyVarSpecific"
+    _ -> error "Language.Finkel.Syntax.Utils:codeToUserTyVarSpecific"
 #elif MIN_VERSION_ghc(9,8,0)
 codeToUserTyVar :: Code -> HTyVarBndrVis
 codeToUserTyVar code =
   case code of
     LForm (L l (Atom (ASymbol name))) ->
       lA l (UserTyVar unused HsBndrRequired (lN l (mkUnqual tvName name)))
-    _ -> error "Language.Finkel.Syntax.SynUtils:codeToUserTyVar"
+    _ -> error "Language.Finkel.Syntax.Utils:codeToUserTyVar"
 codeToUserTyVarSpecific :: Code -> LHsTyVarBndr Specificity PARSED
 codeToUserTyVarSpecific code =
   -- XXX: Does not support 'InferredSpec' yet.
   case code of
     LForm (L l (Atom (ASymbol name))) ->
       lA l (UserTyVar unused SpecifiedSpec (lN l (mkUnqual tvName name)))
-    _ -> error "Language.Finkel.Syntax.SynUtils:codeToUserTyVarSpecific"
+    _ -> error "Language.Finkel.Syntax.Utils:codeToUserTyVarSpecific"
 #elif MIN_VERSION_ghc(9,0,0)
 codeToUserTyVar :: Code -> LHsTyVarBndr () PARSED
 codeToUserTyVar code =
   case code of
     LForm (L l (Atom (ASymbol name))) ->
       lA l (UserTyVar unused () (lN l (mkUnqual tvName name)))
-    _ -> error "Language.Finkel.Syntax.SynUtils:codeToUserTyVar"
+    _ -> error "Language.Finkel.Syntax.Utils:codeToUserTyVar"
 
 codeToUserTyVarSpecific :: Code -> LHsTyVarBndr Specificity PARSED
 codeToUserTyVarSpecific code =
@@ -377,14 +377,14 @@ codeToUserTyVarSpecific code =
     LForm (L l (Atom (ASymbol name))) ->
       lA l (UserTyVar unused SpecifiedSpec (lN l (mkUnqual tvName name)))
       -- XXX: Does not support 'InferredSpec' yet.
-    _ -> error "Language.Finkel.Syntax.SynUtils:codeToUserTyVarSpecific"
+    _ -> error "Language.Finkel.Syntax.Utils:codeToUserTyVarSpecific"
 #else
 codeToUserTyVar :: Code -> HTyVarBndr
 codeToUserTyVar code =
   case code of
     LForm (L l (Atom (ASymbol name))) ->
       L l (UserTyVar unused (L l (mkUnqual tvName name)))
-    _ -> error "Language.Finkel.Syntax.SynUtils:codeToUserTyVar"
+    _ -> error "Language.Finkel.Syntax.Utils:codeToUserTyVar"
 
 codeToUserTyVarSpecific :: Code -> HTyVarBndrSpecific
 codeToUserTyVarSpecific = codeToUserTyVar


### PR DESCRIPTION
Rename the module Language.Finkel.Syntax.SynUtils to Language.Finkel.Syntax.Util.